### PR TITLE
Fix CreateTestReport=false still generating test reports

### DIFF
--- a/tests/tExamplesTester.m
+++ b/tests/tExamplesTester.m
@@ -236,6 +236,43 @@ classdef tExamplesTester < matlab.unittest.TestCase
       testCase.verifyError(@()examplesTester("examples", CleanupFcn="notAFunction"), ...
         expectedError);
     end
+
+    function verifyNoReportWhenCreateTestReportFalse(testCase)
+      % Test verifies that no test report folder is created when
+      % CreateTestReport is set to false
+
+      import matlab.unittest.fixtures.TemporaryFolderFixture
+      testCase.applyFixture(TemporaryFolderFixture);
+
+      outputPath = testCase.createTemporaryFolder;
+
+      obj = examplesTester("examples", CreateTestReport=false, ...
+        OutputPath=outputPath);
+      obj.executeTests();
+
+      testReportFolder = fullfile(outputPath, 'test-report');
+      testCase.verifyEqual(exist(testReportFolder, "dir"), 0, ...
+        "Test report folder should not be created when CreateTestReport is false");
+      testCase.verifyTrue(all([obj.TestResults.Passed]), 'All tests did not pass');
+    end
+
+    function verifyNoOutputDirWhenNoReportsNeeded(testCase)
+      % Test verifies that the output directory is not created when
+      % CreateTestReport is false and no CodeCoveragePlugin is provided
+
+      import matlab.unittest.fixtures.TemporaryFolderFixture
+      testCase.applyFixture(TemporaryFolderFixture);
+
+      outputPath = fullfile(testCase.createTemporaryFolder, 'should-not-exist');
+
+      obj = examplesTester("examples", CreateTestReport=false, ...
+        OutputPath=outputPath);
+      obj.executeTests();
+
+      testCase.verifyEqual(exist(outputPath, "dir"), 0, ...
+        "Output directory should not be created when no reports are needed");
+      testCase.verifyTrue(all([obj.TestResults.Passed]), 'All tests did not pass');
+    end
   end
 
 end

--- a/toolbox/examplesTester.m
+++ b/toolbox/examplesTester.m
@@ -142,62 +142,68 @@ classdef examplesTester < handle
       % Diagnostic record plugin enables logging in the tests
       obj.Runner.addPlugin(DiagnosticsRecordingPlugin);
 
-      if ~exist(obj.OutputPath, "dir")
-        mkdir(obj.OutputPath);
+      % Create output directory if reports are needed
+      if obj.CreateTestReport || ~isempty(obj.CodeCoveragePlugin)
+        if ~exist(obj.OutputPath, "dir")
+          mkdir(obj.OutputPath);
+        end
       end
+
       % Add code coverage plugin
       if ~isempty(obj.CodeCoveragePlugin)
         obj.Runner.addPlugin(obj.CodeCoveragePlugin)
       end
 
       % Add Test Report plugin based on user inputs
-      testReportFolder = fullfile(obj.OutputPath, 'test-report');
+      if obj.CreateTestReport
+        testReportFolder = fullfile(obj.OutputPath, 'test-report');
 
-      % Deleting already present reports folder, as overwrite does not work
-      % for different file formats
+        % Deleting already present reports folder, as overwrite does not work
+        % for different file formats
 
-      if exist(testReportFolder, "dir")
-        disp('Deleting already existing test report folder');
-        rmdir(testReportFolder, 's');
+        if exist(testReportFolder, "dir")
+          disp('Deleting already existing test report folder');
+          rmdir(testReportFolder, 's');
+        end
+        switch(obj.TestReportFormat)
+          case 'html'
+            testReportPlugin = TestReportPlugin.producingHTML(testReportFolder, ...
+              'Verbosity',4);
+
+          case 'docx'
+            % Creating a folder specifically to maintain uniformity in
+            % different formats of the report. 'html' format creates the
+            % test-report folder by default, so creating this folder for
+            % other formats
+
+            mkdir(testReportFolder);
+            testReportPlugin = TestReportPlugin.producingDOCX(fullfile(testReportFolder, 'TestReport.docx'));
+
+          case 'pdf'
+            % Creating a folder specifically to maintain uniformity in
+            % different formats of the report. 'html' format creates the
+            % test-report folder by default, so creating this folder for
+            % other formats
+
+            mkdir(testReportFolder);
+            testReportPlugin = TestReportPlugin.producingPDF(fullfile(testReportFolder, 'TestReport.pdf'));
+
+          case 'xml'
+            % Creating a folder specifically to maintain uniformity in
+            % different formats of the report. 'html' format creates the
+            % test-report folder by default, so creating this folder for
+            % other formats
+
+            mkdir(testReportFolder);
+            testReportPlugin = XMLPlugin.producingJUnitFormat(fullfile(testReportFolder, 'TestReport.xml'));
+
+          otherwise
+
+            error('TestReportFormat is invalid, It can have only following values as input: "html", "Docx", "pdf", "xml"')
+        end      
+
+        obj.Runner.addPlugin(testReportPlugin);
       end
-      switch(obj.TestReportFormat)
-        case 'html'
-          testReportPlugin = TestReportPlugin.producingHTML(testReportFolder, ...
-            'Verbosity',4);
-
-        case 'docx'
-          % Creating a folder specifically to maintain uniformity in
-          % different formats of the report. 'html' format creates the
-          % test-report folder by default, so creating this folder for
-          % other formats
-
-          mkdir(testReportFolder);
-          testReportPlugin = TestReportPlugin.producingDOCX(fullfile(testReportFolder, 'TestReport.docx'));
-
-        case 'pdf'
-          % Creating a folder specifically to maintain uniformity in
-          % different formats of the report. 'html' format creates the
-          % test-report folder by default, so creating this folder for
-          % other formats
-
-          mkdir(testReportFolder);
-          testReportPlugin = TestReportPlugin.producingPDF(fullfile(testReportFolder, 'TestReport.pdf'));
-
-        case 'xml'
-          % Creating a folder specifically to maintain uniformity in
-          % different formats of the report. 'html' format creates the
-          % test-report folder by default, so creating this folder for
-          % other formats
-
-          mkdir(testReportFolder);
-          testReportPlugin = XMLPlugin.producingJUnitFormat(fullfile(testReportFolder, 'TestReport.xml'));
-
-        otherwise
-
-          error('TestReportFormat is invalid, It can have only following values as input: "html", "Docx", "pdf", "xml"')
-      end      
-
-      obj.Runner.addPlugin(testReportPlugin);
     end
 
 


### PR DESCRIPTION
Guard the test report plugin creation and folder setup in initializeTestRunner with obj.CreateTestReport so that no report folder or plugin is created when the user sets CreateTestReport to false. Also guard mkdir(OutputPath) to only run when reports or coverage are actually needed.

Closes #8